### PR TITLE
#8 Add example usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ A REST API web framework for persisting records in a PostgreSQL database.
 - Automatic setting of `created_at` and `last_updated_at` timestamps
 - Automatic setting of `creator_uid` and `last_updater_uid`
 - RDS with IAM credentials
+
+## Examples
+See [Examples docs directory](./docs/examples/)

--- a/docs/examples/direct/README.md
+++ b/docs/examples/direct/README.md
@@ -1,0 +1,16 @@
+# Direct python script invocation example
+
+Navigate to the current directory from the root of this project:
+```shell
+cd docs/examples/direct
+```
+
+First install dependency with:
+```shell
+pip install pygrestqlambda
+```
+
+Then execute the scripts in this directory with, for example:
+```shell
+python json_response.py
+```

--- a/docs/examples/direct/json_response.py
+++ b/docs/examples/direct/json_response.py
@@ -1,0 +1,9 @@
+from pygrestqlambda.aws.lambda_function.rest_api_gateway_proxy_integration import Response
+
+response = Response(
+    body = {
+        'hello': 'world'
+    }
+)
+
+print(response.get_payload())

--- a/docs/examples/direct/string_response.py
+++ b/docs/examples/direct/string_response.py
@@ -1,0 +1,8 @@
+from pygrestqlambda.aws.lambda_function.rest_api_gateway_proxy_integration import Response
+
+response = Response(
+    headers={'Content-Type': 'text/html'},
+    body = 'hello'
+)
+
+print(response.get_payload())

--- a/docs/examples/lambda/Dockerfile
+++ b/docs/examples/lambda/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/python:3.12
+
+RUN pip install pygrestqlambda
+
+COPY app.py ${LAMBDA_TASK_ROOT}
+
+CMD [ "app.handler" ]

--- a/docs/examples/lambda/README.md
+++ b/docs/examples/lambda/README.md
@@ -1,0 +1,35 @@
+# Lambda function docker container example
+
+Navigate to the current directory from the root of this project:
+```shell
+cd docs/examples/lambda
+```
+
+From the current directory, build image with:
+```shell
+docker build -t pygrestqlambda/lambda .
+```
+
+The run the container with:
+```shell
+docker run -p 9095:8080 pygrestqlambda/lambda
+```
+
+In a separate terminal, run the following commands:
+```shell
+curl \
+    -X POST \
+    -d '{"hello": "from terminal"}' \
+    http://127.0.0.1:9095/2015-03-31/functions/function/invocations
+```
+
+The following is returned:
+```json
+{
+    "isBase64Encoded": false,
+    "statusCode": 200,
+    "headers": {"Content-Type": "application/json"},
+    "multiValueHeaders": null,
+    "body": "{\"hello\": \"from lambda handler\", \"original_input\": {\"hello\": \"from terminal\"}}"
+}
+```

--- a/docs/examples/lambda/app.py
+++ b/docs/examples/lambda/app.py
@@ -1,0 +1,23 @@
+"""
+Lambda handler
+"""
+
+import logging
+from pygrestqlambda.aws.lambda_function.rest_api_gateway_proxy_integration import Response
+
+def handler(event: dict, context: dict):
+    """
+    Lambda handler to return supplied JSON in a format expected by AWS REST API Gateway
+    """
+
+    logging.debug(context)
+    response = Response(
+        body={
+            'hello': 'from lambda handler',
+            'original_input': event
+        },
+        status_code=200,
+    )
+    payload = response.get_payload()
+
+    return payload

--- a/docs/examples/local_lambda_gateway_compose/README.md
+++ b/docs/examples/local_lambda_gateway_compose/README.md
@@ -1,0 +1,23 @@
+# REST API Gateway Lambda function docker compose example
+
+Navigate to the current directory from the root of this project:
+```shell
+cd docs/examples/local_lambda_gateway_compose
+```
+
+Start the stack with:
+```shell
+docker compose up --build
+```
+
+In another terminal, make a request to the example endpoint:
+```shell
+curl http://127.0.0.1:9096/example
+```
+
+The following response should be returned:
+```json
+{
+    "hello": "through local OpenAPI REST gateway"
+}
+```

--- a/docs/examples/local_lambda_gateway_compose/docker-compose.yaml
+++ b/docs/examples/local_lambda_gateway_compose/docker-compose.yaml
@@ -1,0 +1,12 @@
+services:
+  rest-api-gateway:
+    image: voquis/local-openapi-aws-rest-api-gateway-lambda
+    volumes:
+      - ./openapi.yaml:/openapi/openapi.yaml:ro
+    ports:
+      - 9096:8080
+    depends_on:
+      - rest-api-lambda
+  rest-api-lambda:
+    build:
+      context: ./lambda

--- a/docs/examples/local_lambda_gateway_compose/lambda/Dockerfile
+++ b/docs/examples/local_lambda_gateway_compose/lambda/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/python:3.12
+
+COPY requirements.txt ${LAMBDA_TASK_ROOT}
+
+RUN pip install -r requirements.txt
+
+COPY . ${LAMBDA_TASK_ROOT}
+
+CMD [ "app.handler" ]

--- a/docs/examples/local_lambda_gateway_compose/lambda/app.py
+++ b/docs/examples/local_lambda_gateway_compose/lambda/app.py
@@ -1,0 +1,22 @@
+"""
+Lambda handler
+"""
+
+import logging
+from pygrestqlambda.aws.lambda_function.rest_api_gateway_proxy_integration import Response
+
+def handler(event: dict, context: dict):
+    """
+    Lambda handler to return supplied JSON in a format expected by AWS REST API Gateway
+    """
+
+    logging.debug(context)
+    response = Response(
+        body={
+            'hello': 'through local OpenAPI REST gateway'
+        },
+        status_code=200,
+    )
+    payload = response.get_payload()
+
+    return payload

--- a/docs/examples/local_lambda_gateway_compose/lambda/requirements.txt
+++ b/docs/examples/local_lambda_gateway_compose/lambda/requirements.txt
@@ -1,0 +1,1 @@
+pygrestqlambda

--- a/docs/examples/local_lambda_gateway_compose/openapi.yaml
+++ b/docs/examples/local_lambda_gateway_compose/openapi.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.1
+info:
+  title: Example API
+  version: 0.0.2
+servers:
+- url: http://127.0.0.1:9096
+paths:
+  /example:
+    get:
+      responses:
+        '200':
+          description: An example response.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hello:
+                    type: string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["hatchling"]
 
 [project]
 name = "pygrestqlambda"
-version = "0.0.1"
+version = "0.0.2"
 description = "PostgreSQL REST API framework for AWS Lambda functions"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Adds docs with instructions on using the library in the following
scenarios:
- Directly as a python script
- Embedded into a local lambda
- Embedded into a local lambda accessed via a local REST API gateway
