### PR TITLE
#35 Split unit and integration tests

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -18,14 +18,22 @@ echo "Running pylint"
 pylint src tests
 
 # Run tests and generate coverage reports
-echo "Running pytest"
+echo "Running pytest unit tests"
 pytest --cov="$PACKAGE_NAME" \
   -n auto \
   --cov-report term \
   --cov-report html \
   --cov-fail-under=100.00 \
-   -o log_cli=true \
-   --log-cli-level=INFO
+  -o log_cli=true \
+  --log-cli-level=INFO \
+  tests/unit
+
+echo "Running pytest integration tests"
+pytest \
+  -n auto \
+  -o log_cli=true \
+  --log-cli-level=INFO \
+  tests/integration
 
 # Check the build
 python -m build


### PR DESCRIPTION
Integration tests are slow because of Docker container dependency. This
change splits unit and integration tests, to improve the development
cycle while making changes quickly.
